### PR TITLE
Get GCS Client via `GOOGLE_CREDENTIALS` .env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,19 @@ Some examples for these addressing schemes:
 
 #### GCS Authentication
 
-In order to access to GCS, authentication credentials should be provided. More information can be found [here](https://cloud.google.com/docs/authentication/getting-started)
+In order to access GCS, authentication credentials should be provided.
+
+If running `go-getter` on a GCP compute resource, authentication can occur via the service account attached to
+that compute resource (such as when running `go-getter` from a Google Kubernetes Engine instance).
+
+Otherwise, options for environment-variable based authentication include:
+- `GOOGLE_0AUTH_ACCESS_TOKEN` - A raw Google Cloud Platform 0Auth access token.
+- `GOOGLE_APPLICATION_CREDENTIALS` - The path to your service account's key file.
+- `GOOGLE_CREDENTIALS` - Your service account's key file contents but without new lines or tabs.
+
+Any one of the above environment variable options is by themselves sufficient for authentication to GCS. 
+
+More information can be found [here](https://cloud.google.com/docs/authentication/getting-started)
 
 #### GCS Bucket Examples
 

--- a/get_gcs.go
+++ b/get_gcs.go
@@ -212,6 +212,11 @@ func (g *GCSGetter) getClient(ctx context.Context) (client *storage.Client, err 
 		opts = append(opts, option.WithTokenSource(tokenSource))
 	}
 
+	if v, ok := os.LookupEnv("GOOGLE_CREDENTIALS"); ok {
+		vBytes := []byte(v)
+		opts = append(opts, option.WithCredentialsJSON(vBytes))
+	}
+
 	newClient, err := storage.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/get_gcs_test.go
+++ b/get_gcs_test.go
@@ -259,3 +259,25 @@ func TestGCSGetter_GetFile_OAuthAccessToken(t *testing.T) {
 	}
 	assertContents(t, dst, "# Main\n")
 }
+
+func TestGCSGetter_GetFile_Credentials(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") == "" {
+		t.Skip("Skipping; set GOOGLE_CREDENTIALS to run")
+	}
+	g := new(GCSGetter)
+	dst := tempTestFile(t)
+	defer os.RemoveAll(filepath.Dir(dst))
+
+	// Download
+	err := g.GetFile(
+		dst, testURL("https://www.googleapis.com/storage/v1/go-getter-test/go-getter/folder/main.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify the main file exists
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	assertContents(t, dst, "# Main\n")
+}


### PR DESCRIPTION
Resolves the first bullet point of https://github.com/dragondrop-cloud/dragondrop-cloud/issues/354.